### PR TITLE
Allow upper case in GitHub username

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,29 +1,37 @@
 const { join } = require('node:path');
 const { readFileSync } = require('node:fs');
 
-const lockfile = join(process.env.GITHUB_WORKSPACE, 'package-lock.json');
-const matcher = /.+\/(?<repo>[\w-]+\/[\w-]+)\.git#(?<hash>[0-9a-f]+)/;
+const lockfile = join(process.env.GITHUB_WORKSPACE ?? process.cwd(), 'package-lock.json');
+const matcher = /.+github\.com\/(?<repo>[\w-]+\/[\w-]+)\.git#(?<hash>[0-9a-f]+)/;
 
-function getBody() {
+/** @param {import('@actions/core')} core */
+function getBody(core) {
   const { packages } = JSON.parse(readFileSync(lockfile, 'utf8'));
   return Object.entries(packages).slice(1).map(([key, value]) => {
     if (value.resolved.startsWith('git')) {
-      const { repo, hash } = matcher.exec(value.resolved).groups;
-      return `- [${repo}@\`${hash}\`](https://github.com/${repo}/commit/${hash})`;
+      const match = matcher.exec(value.resolved)
+      if (match) {
+        // @ts-ignore
+        const { repo, hash } = match.groups;
+        return `- [${repo}@\`${hash}\`](https://github.com/${repo}/commit/${hash})`;
+      } else {
+        core.warning(`URL: ${value.resolved}`, { file: lockfile, title: 'Failed to parse URL' })
+        return `- ${value.resolved}`;
+      }
     }
     const name = key.substring(13), version = value.version;
     return `- [${name}@\`${version}\`](https://www.npmjs.com/package/${name}/v/${version})`;
   }).join('\n');
 }
 
-/** @param {import('@types/github-script').AsyncFunctionArguments} */
+/** @param {import('github-script').AsyncFunctionArguments} */
 module.exports = async function({core, exec}) {
   core.summary.addRaw('## Old versions', true);
-  core.summary.addRaw(getBody(), true).addEOL();
+  core.summary.addRaw(getBody(core), true).addEOL();
   await core.summary.write();
   await exec.exec('npm', ['update']);
 
-  const body = getBody();
+  const body = getBody(core);
   core.summary.addRaw('## New versions', true);
   core.summary.addRaw(body, true).addEOL();
   await core.summary.write();

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ const { join } = require('node:path');
 const { readFileSync } = require('node:fs');
 
 const lockfile = join(process.env.GITHUB_WORKSPACE, 'package-lock.json');
-const matcher = /.+\/(?<repo>[a-z-]+\/[a-z-]+)\.git#(?<hash>[0-9a-f]+)/;
+const matcher = /.+\/(?<repo>[\w-]+\/[\w-]+)\.git#(?<hash>[0-9a-f]+)/;
 
 function getBody() {
   const { packages } = JSON.parse(readFileSync(lockfile, 'utf8'));


### PR DESCRIPTION
At the moment, the update action will fail when the git repo to update from contains an uppercase letter. E.g. https://github.com/tree-sitter-grammars/tree-sitter-slang/blob/master/package-lock.json#L411 will lead to https://github.com/tree-sitter-grammars/tree-sitter-slang/actions/runs/8854290751/job/24317029513

https://regex101.com/r/WRs3U6/1

TODO:
- [x] test the new code: